### PR TITLE
Make lit package search more user-friendly

### DIFF
--- a/pages/lit.html
+++ b/pages/lit.html
@@ -8,7 +8,7 @@ Here you can search for packages that are published to the public package reposi
 
 The search term is a lua pattern and currently only matches author names or package names.
 
-Soon more advanced matches will come.  Try searches like `.*`, `coro`, `luvit`, or `msgpack`.
+Soon more advanced matches will come.  Try searches like `*`, `coro`, `luvit`, or `msgpack`.
 
 ]]
 }

--- a/static/lit-browser.js
+++ b/static/lit-browser.js
@@ -5,7 +5,7 @@ window.addEventListener("load", function () {
 function SearchApp(emit, refresh) {
   var matches = null, text = "", querying = false, xhr = null;
 
-  var initialSearch = ".*/";
+  var initialSearch = "*/";
   if (window.location.hash) {
     initialSearch = window.location.hash.substring(1);
   }
@@ -34,7 +34,7 @@ function SearchApp(emit, refresh) {
   }
 
   function search(query) {
-    if (!query || query.trim() === "") { query = ".*" }
+    if (!query || query.trim() === "") { query = "*" }
     if (xhr !== null) { xhr.onload = function() {} }
     querying = true;
     text = query


### PR DESCRIPTION
- Initialize the page with a search of `*/` (all authors)
- Use the URL fragment for search queries/history
- Better feedback when searches have no results
- Stop old searches overwriting the results of newer ones
- Make various parts of each card initiate relevant searches (all packages of an author, dependencies, etc)
- Automatically convert blank searches to `*` (all packages and authors)

Relies on https://github.com/luvit/lit/pull/76

**Note:** I have little experience with javascript. I basically just went with whatever I could get working, so this could probably do with **a lot** of cleanup.
