### PR TITLE
Enforce TLS 1.2 in PowerShell download

### DIFF
--- a/pages/install.html
+++ b/pages/install.html
@@ -16,7 +16,7 @@ curl -L https://github.com/luvit/lit/raw/master/get-lit.sh | sh
 If you're on windows, run the sister command in your `cmd.exe` command prompt.
 
 ```bat
-PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://github.com/luvit/lit/raw/master/get-lit.ps1'))"
+PowerShell -NoProfile -ExecutionPolicy unrestricted -Command "[Net.ServicePointManager]::SecurityProtocol = 'Tls12'; iex ((new-object net.webclient).DownloadString('https://github.com/luvit/lit/raw/master/get-lit.ps1'))"
 ```
 
 Put both `lit` and `luvit` in your path somewhere.  We recommend `/usr/local/bin` or `$HOME/bin` if that's in your path.


### PR DESCRIPTION
luvit/lit#234
luvit/luvit#1026

Credit to @squeek502 and https://stackoverflow.com/questions/41618766/powershell-invoke-webrequest-fails-with-ssl-tls-secure-channel