### PR TITLE
Update Discord invite link

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -122,7 +122,7 @@ contributors.
 
 Join us on freenode IRC at [#luvit](irc://chat.freenode.net/#luvit), 
 the [Luvit Mailing list](https://groups.google.com/forum/#!forum/luvit), or
-the [Discord Server](https://discord.gg/5hmFh7t)
+the [Discord Server](https://discord.gg/luvit)
 
 We'll be publishing tutorials here at the [luvit blog](/blog/) soon, stay
 tuned.


### PR DESCRIPTION
Since creating a Discord server, we've been verified by Discord as an official open source community. Luvit.io is now featured on https://discordapp.com/open-source. With this, we were also able to secure a custom invite link. This commit updates that link on the Luvit.io website.