### PR TITLE
Community links

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -120,9 +120,7 @@ contributors.
 
 ## Dive In
 
-Join us on freenode IRC at [#luvit](irc://chat.freenode.net/#luvit), 
-the [Luvit Mailing list](https://groups.google.com/forum/#!forum/luvit), or
-the [Discord Server](https://discord.gg/luvit)
+Join us on [Discord](https://discord.gg/luvit) or the [Luvit Mailing list](https://groups.google.com/forum/#!forum/luvit)
 
 We'll be publishing tutorials here at the [luvit blog](/blog/) soon, stay
 tuned.


### PR DESCRIPTION
I removed the IRC link in line with luvit/luvit#1138. The mailing list is kind of dead and overridden with spam. Do we still maintain that?