### PR TITLE
Improve readability of the copyright text

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -179,6 +179,7 @@ footer {
   background-color: #FFBF28;
   text-align: center;
   color: #000000;
+  font-weight: 600;
 }
 .page-header {
   background-color: #0594bd;

--- a/static/style.css
+++ b/static/style.css
@@ -176,7 +176,7 @@ footer {
   height: 56px;
   overflow-x: auto;
   overflow-y: hidden;
-  background-color: #ffb300;
+  background-color: #FFBF28;
   text-align: center;
   color: #000000;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -178,7 +178,7 @@ footer {
   overflow-y: hidden;
   background-color: #ffb300;
   text-align: center;
-  color: #fff;
+  color: #000000;
 }
 .page-header {
   background-color: #0594bd;


### PR DESCRIPTION
See commit messages for the "why" :)

Before:

![image](https://user-images.githubusercontent.com/16489133/128095521-09c64df6-8c10-4035-86fa-1c1c2c4b3a9e.png)

After (copyright date update not included):

![image](https://user-images.githubusercontent.com/16489133/128095555-90960a75-4507-4af6-8646-243838d3dd68.png)

Edit: Without the increase to the font weight, it looks like this - not sure if that's better?

![image](https://user-images.githubusercontent.com/16489133/128096194-ad732fb5-ede8-42fa-b6bd-dedd334917d7.png)
