### PR TITLE
Update copyright date displayed in the footer

### DIFF
--- a/templates/layout.html
+++ b/templates/layout.html
@@ -35,7 +35,7 @@
   </div>
   <footer>
     <div class="row">
-      <p>Copyright 2015-2018 The Luvit Authors</p>
+      <p>Copyright 2015-2021 The Luvit Authors</p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
It's not making a good first impression on potential users if the main website appears to be three years out of date.